### PR TITLE
Cap visible player amount at 24

### DIFF
--- a/frontend/src/component/Servers.tsx
+++ b/frontend/src/component/Servers.tsx
@@ -71,7 +71,7 @@ const ServerRow = ({ server }: ServerRowProps) => {
             <Grid item xs={1} className={classes.item}>
                 <Typography variant={'h2'}
                             className={classes.h2}
-                            gutterBottom={false}>{server?.a2s?.Players || 0} / {server?.a2s?.MaxPlayers || 32}</Typography>
+                            gutterBottom={false}>{(server?.a2s?.Players > 24 ? 24 : server?.a2s?.Players) || 0} / {server?.a2s?.MaxPlayers || 24}</Typography>
             </Grid>
             <Grid item xs={2} className={classes.item}>
                 <Button className={classes.button} onClick={() => {


### PR DESCRIPTION
Turned 25/24->24/24.

Also fixes showing 0/32 when servers are down.

Not tested. I know basically nothing about Go or React. Should work based on how regular JavaScript does